### PR TITLE
patch aws.s3 install

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     knitr,
     testthat,
     covr
-Remotes: jimhester/archive, cloudyr/aws.s3
+Remotes: jimhester/archive, cloudyr/aws.s3@v0.3.12
 VignetteBuilder: knitr
 X-schema.org-applicationCategory: Antarctic/Southern Ocean
 X-schema.org-keywords: ropensci, Antarctic, Southern Ocean, data, environmental, satellite, climate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     knitr,
     testthat,
     covr
-Remotes: jimhester/archive, cloudyr/aws.s3@v0.3.12
+Remotes: jimhester/archive, cloudyr/aws.s3@8c722f8
 VignetteBuilder: knitr
 X-schema.org-applicationCategory: Antarctic/Southern Ocean
 X-schema.org-keywords: ropensci, Antarctic, Southern Ocean, data, environmental, satellite, climate


### PR DESCRIPTION
aws.s3 was recently orphaned (https://github.com/cloudyr/aws.s3/commit/c0c5d8d9e292236183606022e9516bd20d3b29b5) which prevents installing from github.  This breaks installation of aws.s3, which also breaks installation of `bowerbird` from github.  By pinning to the last release version instead of going for `master`, `bowerbird` can again be installed successfully by `install_github()`